### PR TITLE
修复当日期为31号时，获取下月日期数据错误的bug

### DIFF
--- a/src/kalendar.js
+++ b/src/kalendar.js
@@ -31,6 +31,7 @@ export default class Kalendar {
         let idx = 0
         do {
             const date = this.startDate
+            date.setDate(1)
             date.setMonth(date.getMonth() + idx)
             const monthTable = Kalendar.monthly({date, mount, weekStart, unifiedMount})
             table[utils.getChinaStandard(date, true)] = monthTable


### PR DESCRIPTION
![1540974455501](https://user-images.githubusercontent.com/9859859/47775245-170ea200-dd2a-11e8-89b2-f2b634526cf7.jpg)

以官方demo为例，当日期为2018-10-31日时，使用new Kalendar创建日期数据，会在_create()函数中，使用setMonth时，造成JS日期溢出。需在setMonth之前setDate解决此bug
```
_create() {
        const {mount, weekStart, unifiedMount} = this
        const table = {}
        let count = (this.endDate.getFullYear() * 12 + this.endDate.getMonth() + 1)
            - (this.startDate.getFullYear() * 12 + this.startDate.getMonth() + 1)
        if (count < 0) return null
        let idx = 0
        do {
            const date = this.startDate
            date.setDate(1)
            date.setMonth(date.getMonth() + idx)
            const monthTable = Kalendar.monthly({date, mount, weekStart, unifiedMount})
            table[utils.getChinaStandard(date, true)] = monthTable
            count--
            idx++
        } while (count > 0)
        return table
    }
```